### PR TITLE
Update configs and docs to use latest OpenTelemetry Functions (also terraform dashboards)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -348,3 +348,40 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+
+# Local .terraform 
+.terraform.lock.hcl
+**/.terraform/*
+.terraform*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data, such as
+# password, private keys, and other secrets. These should not be part of version 
+# control as they are data points which are potentially sensitive and subject 
+# to change depending on the environment.
+*.tfvars
+*.tfvars.json
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@
 ## OTEL collector is setup. I've installed the Jenkins OTEL plug using the Jenkins Plugin Manager. How do I configure the Jenkins OTEL plugin?
 - Add your OTEL Collector Instance's IP and the appropriate port to the `OTLP GRPC ENDPOINT` field in Manage Jenkins > Configure System.  
     - Default port: `4317`
+        - Note: In this example we will use the default port for jenkins data specifically. If you are sending other otlp data to port `4317` open another port for jenkins and change the port for `otlp/jenkins` in the receiver config.
         - If needed verify open ports on the opentelemetry collector instance:
             ```
             # sudo netstat -tulpn | grep LISTEN        
@@ -114,14 +115,14 @@ To create time series metrics from your Jenkins APM data use the OTEL `transform
 
 ## How can I Setup a detector on Jenkins deployments using OTEL data? 
 1. Create a detector [using the V2 detector url](https://app.us1.signalfx.com/#/detector/v2/new) to leverage a SignalFlow query.
-    - Example SignalFlow for Service Name: `jenkins-service` and Workflow (pipeline): `Big Pipeline` in the `test` environment:
+    - Example SignalFlow for Service Name: `jenkins-service` and Workflow (pipeline): `Scheduled Buttercup Containers Build` in the `test` environment:
     ```
-    AllReq = data('workflows.count', filter=filter('sf_workflow', 'doug-jenkins:Scheduled Buttercup Containers Build') and filter('sf_environment', 'test') and (not filter('sf_dimensionalized', '*'))).sum(by=['sf_workflow']).publish(label='Success', enable=False)
-    Error = data('workflows.count', filter=filter('sf_workflow', 'doug-jenkins:Scheduled Buttercup Containers Build') and filter('sf_environment', 'test') and (not filter('sf_dimensionalized', '*')) and filter('sf_error', 'false')).sum(by=['sf_workflow']).publish(label='Error', enable=False)
+    AllReq = data('workflows.count', filter=filter('sf_workflow', 'jenkins-service:Scheduled Buttercup Containers Build') and filter('sf_environment', 'test') and (not filter('sf_dimensionalized', '*'))).sum(by=['sf_workflow']).publish(label='Success', enable=False)
+    Error = data('workflows.count', filter=filter('sf_workflow', 'jenkins-service:Scheduled Buttercup Containers Build') and filter('sf_environment', 'test') and (not filter('sf_dimensionalized', '*')) and filter('sf_error', 'false')).sum(by=['sf_workflow']).publish(label='Error', enable=False)
     ErrRate = (100*(AllReq-Error)/AllReq).publish(label='ErrRate')
 
     from signalfx.detectors.apm.workflow_errors.static_v2 import static as workflow_errors_sudden_static_v2
-    workflow_errors_sudden_static_v2.detector(filter_=((filter('sf_workflow', 'doug-jenkins:Scheduled Buttercup Containers Build'))) and (filter('sf_environment', 'test')), custom_filter=None, current_window='30m', fire_rate_threshold=0.1, clear_rate_threshold=0, attempt_threshold=1).publish('Buttercup Build Failure - APM')
+    workflow_errors_sudden_static_v2.detector(filter_=((filter('sf_workflow', 'jenkins-service:Scheduled Buttercup Containers Build'))) and (filter('sf_environment', 'test')), custom_filter=None, current_window='30m', fire_rate_threshold=0.1, clear_rate_threshold=0, attempt_threshold=1).publish('Buttercup Build Failure - APM')
     ```
 2. Add your detector to the Event Overlay for your dashboards and charts!
     - Dashboard Overlay Example:
@@ -133,12 +134,3 @@ To create time series metrics from your Jenkins APM data use the OTEL `transform
         3. Click the `Chart Options` tab and select `Show events as lines` and `Show data markers` 
         ![Add Event Lines and Data Markers to Chart](./images/Chart-Options-Markers.png)
 - **PRO-TIP:** Detectors can also be added for another team's deployments if the health of your own could be impacted by a failed deployment.
-
-
-
-
-
-
-
-
-

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## How can we use the Jenkins OTEL plugin to get data in to Splunk?
 
 - [Jenkins OTEL plugin](https://plugins.jenkins.io/opentelemetry/#getting-started) (by Cyrille Le Clerc) can be used with an [OTEL collector](https://github.com/signalfx/splunk-otel-collector) to send APM data to Splunk Observability Cloud (formerly SignalFx) APM, and Splunk HEC
-    - Quick linux install: 
+    - Quick linux install of Splunks OTEL collector: 
         ```
             curl -sSL https://dl.signalfx.com/splunk-otel-collector.sh > /tmp/splunk-otel-collector.sh && \
             sudo sh /tmp/splunk-otel-collector.sh --realm $SPLUNK_REALM -- $SPLUNK_ACCESS_TOKEN
@@ -14,9 +14,9 @@
 
 - **NOTE:** OTEL can be setup to send APM data to Splunk APM, Spunk Enterprise HEC, Splunk Log Observer, or all three! Config below is for sending to all three.
 
-1. Config for [Splunk Otel Variables](./splunk-otel-collector.conf) (default location on instance is `/etc/otel/collector/splunk-otel-collector.conf`)
+1. Config for [Splunk Otel Variables](./splunk-otel-collector.conf) (default location on install is `/etc/otel/collector/splunk-otel-collector.conf`)
 
-2. Config for [OTEL Agent](./agent_config.yaml) (default location on instance is `/etc/otel/collector/agent_config.yaml`)
+2. Config for [OTEL Agent](./agent_config.yaml) (default location on install is `/etc/otel/collector/agent_config.yaml`)
     - Pay special attention to the additional `environment` attribute / tag we're adding to each trace. SignalFX APM utilizes this attribute by default
         ```
         attributes:
@@ -100,14 +100,14 @@
 ## I've verified traces are going in to Splunk APM. Where should I see my Jenkins Instance in Splunk APM?
 - Splunk APM will show your Jenkins instance as the same value you have input in The Jenkins OpenTelemetry Plugin setup's `Service name` and `Service namespace` settings
 - Each of the Pipelines running in the Jenkins instance will be treated as a Service Endpoint in Splunk APM
-- A basic [Jenkins dashboard](./dashboards/Jenkins-Service-Endpoint-OTEL-APM.json) is included in this repository as a starting point
+- Basic [Jenkins dashboards](./dashboards/) are included in this repository as a starting point
     1. Filter by your environment variable
     2. Filter by your Jenkins Service Name
     3. Filter by your Pipeline (or * for all pipelines)
     4. Edit Event Overlay to match detectors (I.E. Detector for build failures)
 ![Service Endpoint Dashboard](./images/Jenkins-Service-Endpoint-OTEL-APM.png)
 
-## Using OTEL connectors and processors to get a better overview of the Overall Jenkins Health and specific metrics around individual steps over time?
+## Using OTEL connectors and processors to get a better overview of the Overall Jenkins Health and specific metrics around individual steps over time
 To create time series metrics from your Jenkins APM data use the OTEL `transform` processor and `spanmetrics` connector to metricize the APM span data. This allows you to plot those values historically even if your Jenkins APM data has aged out of Splunk APM.
 - **Note:** This requires enhancing your OTEL Collector config to send the Jenkins APM data through the `transform` processor and `spanmetrics` connector as detailed [above](#what-does-the-otel-config-look-like)
 
@@ -124,6 +124,7 @@ To create time series metrics from your Jenkins APM data use the OTEL `transform
     from signalfx.detectors.apm.workflow_errors.static_v2 import static as workflow_errors_sudden_static_v2
     workflow_errors_sudden_static_v2.detector(filter_=((filter('sf_workflow', 'jenkins-service:Scheduled Buttercup Containers Build'))) and (filter('sf_environment', 'test')), custom_filter=None, current_window='30m', fire_rate_threshold=0.1, clear_rate_threshold=0, attempt_threshold=1).publish('Buttercup Build Failure - APM')
     ```
+    - Note: other dimensions such as `sf_service` (I.E. Jenkins service name) and `sf_operation` (I.E. pipeline name) can also be used along with metrics like `spans.count` to create detectors
 2. Add your detector to the Event Overlay for your dashboards and charts!
     - Dashboard Overlay Example:
     ![Add Detector Events to Dashboard](./images/Dashboard-Detector-Events.png)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## How can we use the Jenkins OTEL plugin to get data in to Splunk?
 
-- [Jenkins OTEL plugin](https://plugins.jenkins.io/opentelemetry/#getting-started) (by Cyrille Le Clerc) can be used with an [OTEL collector](https://github.com/signalfx/splunk-otel-collector) to send APM data to Splunk Observability Cloud (formerly SignalFx) APM, and Splunk HEC
+- [Jenkins OTEL plugin](https://plugins.jenkins.io/opentelemetry/#getting-started) (by Cyrille Le Clerc) can be used with an [OTEL collector](https://github.com/signalfx/splunk-otel-collector) to send APM data to Splunk Observability Cloud (formerly SignalFx) APM, and/or Splunk HEC (if desired)
     - Quick linux install of Splunks OTEL collector: 
         ```
             curl -sSL https://dl.signalfx.com/splunk-otel-collector.sh > /tmp/splunk-otel-collector.sh && \
@@ -100,11 +100,11 @@
 ## I've verified traces are going in to Splunk APM. Where should I see my Jenkins Instance in Splunk APM?
 - Splunk APM will show your Jenkins instance as the same value you have input in The Jenkins OpenTelemetry Plugin setup's `Service name` and `Service namespace` settings
 - Each of the Pipelines running in the Jenkins instance will be treated as a Service Endpoint in Splunk APM
-- Basic [Jenkins dashboards](./dashboards/) are included in this repository as a starting point
-    1. Filter by your environment variable
-    2. Filter by your Jenkins Service Name
-    3. Filter by your Pipeline (or * for all pipelines)
-    4. Edit Event Overlay to match detectors (I.E. Detector for build failures)
+- Basic [Jenkins dashboards](./dashboards/) are included in this repository as a starting point (both as [JSON for import](https://docs.splunk.com/Observability/data-visualization/dashboards/dashboards-import-export.html) and Terraform files)
+    1. Filter by your `environment` variable
+    2. Filter by your Jenkins `Service Name`
+    3. Filter by your Pipeline (or `*` for all pipelines)
+    4. Edit [Event Overlay](https://docs.splunk.com/Observability/metrics-and-metadata/view-data-events.html#view-events) to match detectors (I.E. Detector for build failures) and show markers on your dashboards
 ![Service Endpoint Dashboard](./images/Jenkins-Service-Endpoint-OTEL-APM.png)
 
 ## Using OTEL connectors and processors to get a better overview of the Overall Jenkins Health and specific metrics around individual steps over time

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 ## What does the OTEL config look like? 
 
-- **NOTE:** OTEL can be setup to send APM data to Splunk APM, Spunk Enterprise HEC, Splunk Log Observer, or all three! Config below is for sending to all three.
+- **NOTE:** OTEL can be setup to send APM data to Splunk APM and/or Splunk HEC. Configurations for both options are included in this repo.
 
 1. Config for [Splunk Otel Variables](./splunk-otel-collector.conf) (default location on install is `/etc/otel/collector/splunk-otel-collector.conf`)
 

--- a/agent_config_minimal.yaml
+++ b/agent_config_minimal.yaml
@@ -33,8 +33,6 @@ extensions:
     size_mib: ${SPLUNK_BALLAST_SIZE_MIB}
 
 receivers:
-  fluentforward:
-    endpoint: 127.0.0.1:8006
   hostmetrics:
     collection_interval: 10s
     scrapers:
@@ -51,16 +49,6 @@ receivers:
       processes:
       # System processes metrics, disabled by default
       # process:
-  jaeger:
-    protocols:
-      grpc:
-        endpoint: 0.0.0.0:14250
-      thrift_binary:
-        endpoint: 0.0.0.0:6832
-      thrift_compact:
-        endpoint: 0.0.0.0:6831
-      thrift_http:
-        endpoint: 0.0.0.0:14268
   otlp/jenkins:
     protocols:
       grpc:
@@ -80,17 +68,14 @@ receivers:
           - source_labels: [ __name__ ]
             regex: '.*grpc_io.*'
             action: drop
-  smartagent/signalfx-forwarder:
-    type: signalfx-forwarder
-    listenAddress: 0.0.0.0:9080
   signalfx:
     endpoint: 0.0.0.0:9943
-  zipkin:
-    endpoint: 0.0.0.0:9411
 
+# Connectors allow creating telemetry (metrics, logs, etc) from other opentelemetry data
 connectors:
   # spanmetrics connector will pull span metrics out of our trace data with dimensions for pipeline id, step name, step type.
   # Any other dimensions (span tags) can also be added here to put those dimensions onto the spanmetrics
+  # https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/f195900aa20617dca2370df638f4776a0ffc160e/connector/spanmetricsconnector
   spanmetrics/jenkins:
     histogram:
       explicit:
@@ -105,6 +90,7 @@ connectors:
     dimensions_cache_size: 1000
     namespace: jenkins      
 
+# Processors allow you to manipulate opentelemetry data in transit
 processors:
   # Transform processor to enrich jenkins span data
   transform/jenkinstrace:
@@ -114,9 +100,10 @@ processors:
           - set(attributes["jenkins.pipeline.step.name"], name) where attributes["jenkins.pipeline.step.name"] == nil  
           - set(attributes["jenkins.pipeline.step.type"], name) where attributes["jenkins.pipeline.step.type"] == nil
   
-  # Enabling the batch memory_limiter is strongly recommended for every pipeline.
   batch:
-    memory_limiter:
+
+  # Enabling the memory_limiter is strongly recommended for every pipeline.
+  memory_limiter:
     check_interval: 2s
     limit_mib: ${SPLUNK_MEMORY_LIMIT_MIB}
   
@@ -136,7 +123,7 @@ processors:
     actions:
     - key: environment
       value: test
-      action: insert
+      action: upsert
 
 
 
@@ -152,12 +139,6 @@ exporters:
     ingest_url: "${SPLUNK_INGEST_URL}"
     sync_host_metadata: true
     correlation:
-  # Logs
-  splunk_hec:
-    token: "${SPLUNK_HEC_TOKEN}"
-    endpoint: "${SPLUNK_HEC_URL}"
-    source: "otel"
-    sourcetype: "otel"
   # Send to gateway
   otlp:
     endpoint: "${SPLUNK_GATEWAY_URL}:4317"
@@ -170,7 +151,7 @@ service:
   extensions: [health_check, http_forwarder, zpages, memory_ballast]
   pipelines:
     traces:
-      receivers: [jaeger, otlp/jenkins, smartagent/signalfx-forwarder, zipkin]
+      receivers: [otlp/jenkins]
       processors:
       - transform/jenkinstrace
       - memory_limiter
@@ -179,9 +160,9 @@ service:
       - resourcedetection
       exporters: [sapm, signalfx, spanmetrics/jenkins]
       # Use instead when sending to gateway
-      #exporters: [otlp, signalfx]
+      #exporters: [otlp, signalfx, spanmetrics/jenkins]
     metrics:
-      receivers: [hostmetrics, otlp, signalfx, smartagent/signalfx-forwarder, spanmetrics/jenkins]
+      receivers: [hostmetrics, otlp, signalfx, spanmetrics/jenkins]
       processors: [memory_limiter, batch, resourcedetection]
       exporters: [signalfx]
       # Use instead when sending to gateway
@@ -190,20 +171,5 @@ service:
       receivers: [prometheus/internal]
       processors: [memory_limiter, batch, resourcedetection/internal]
       exporters: [signalfx]
-      # Use instead when sending to gateway
-      #exporters: [otlp]
-    logs/signalfx:
-      receivers: [signalfx]
-      processors: [memory_limiter, batch]
-      exporters: [signalfx]
-      # Use instead when sending to gateway
-      #exporters: [otlp]
-    logs:
-      receivers: [fluentforward, otlp]
-      processors:
-      - memory_limiter
-      - batch
-      - resourcedetection
-      exporters: [splunk_hec]
       # Use instead when sending to gateway
       #exporters: [otlp]

--- a/dashboards/dashboard_Jenkins-APM-Service-Endpoints.json
+++ b/dashboards/dashboard_Jenkins-APM-Service-Endpoints.json
@@ -2,6 +2,7 @@
   "chartExports": [
     {
       "chart": {
+        "autoDetectRelatedDetectorIds": [],
         "created": 0,
         "creator": null,
         "customProperties": {},
@@ -39,6 +40,7 @@
             ]
           },
           "maximumPrecision": 4,
+          "noDataOptions": null,
           "programOptions": {
             "disableSampling": false,
             "maxDelay": 0,
@@ -47,7 +49,7 @@
           },
           "publishLabelOptions": [
             {
-              "displayName": "Jobs Started (1d)",
+              "displayName": "Spans Started (1d)",
               "label": "A",
               "paletteIndex": 6,
               "plotType": null,
@@ -57,7 +59,7 @@
               "yAxis": 0
             },
             {
-              "displayName": "Jobs Failed (1d)",
+              "displayName": "Spans Failed (1d)",
               "label": "B",
               "paletteIndex": 13,
               "plotType": null,
@@ -96,14 +98,15 @@
     },
     {
       "chart": {
+        "autoDetectRelatedDetectorIds": [],
         "created": 0,
         "creator": null,
         "customProperties": {},
-        "description": "Top pipelines by number of runs",
+        "description": "Top pipelines by number of Jobs",
         "id": "FAZXlLVAwAc",
         "lastUpdated": 0,
         "lastUpdatedBy": null,
-        "name": "Top pipelines by runs (1h)",
+        "name": "Top pipelines by Jobs (1h)",
         "options": {
           "colorBy": "Dimension",
           "colorScale2": null,
@@ -137,6 +140,11 @@
             ]
           },
           "maximumPrecision": null,
+          "noDataOptions": {
+            "linkText": null,
+            "linkUrl": null,
+            "noDataMessage": null
+          },
           "programOptions": {
             "disableSampling": false,
             "maxDelay": 30000,
@@ -156,8 +164,8 @@
             }
           ],
           "refreshInterval": null,
-          "secondaryVisualization": "None",
-          "sortBy": "-value",
+          "secondaryVisualization": "Sparkline",
+          "sortBy": "",
           "time": {
             "range": 900000,
             "rangeEnd": 0,
@@ -167,13 +175,14 @@
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "filter_ = filter('sf_environment', '*') and filter('sf_service', '*') and filter('sf_kind', 'SERVER', 'CONSUMER') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*'))\nA = data('spans.count', filter=filter_, rollup='sum', extrapolation='last_value').sum(by=['sf_environment', 'sf_service', 'sf_operation', 'sf_httpMethod'], allow_missing=['sf_httpMethod']).sum(over='1h').mean(over='1m').top(count=10).publish(label='A')",
+        "programText": "filter_ = filter('sf_environment', '*') and filter('sf_service', '*') and filter('sf_operation', '*') and filter('sf_kind', 'SERVER', 'CONSUMER') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*'))\nA = data('spans.count', filter=filter_, rollup='sum', extrapolation='last_value').sum(by=['sf_environment', 'sf_service', 'sf_operation', 'sf_httpMethod'], allow_missing=['sf_httpMethod']).sum(over='1h').top(count=10).publish(label='A')",
         "relatedDetectorIds": [],
         "tags": null
       }
     },
     {
       "chart": {
+        "autoDetectRelatedDetectorIds": [],
         "created": 0,
         "creator": null,
         "customProperties": {},
@@ -220,6 +229,7 @@
           "lineChartOptions": {
             "showDataMarkers": false
           },
+          "noDataOptions": null,
           "onChartLegendOptions": {
             "dimensionInLegend": null,
             "showLegend": false
@@ -280,6 +290,7 @@
     },
     {
       "chart": {
+        "autoDetectRelatedDetectorIds": [],
         "created": 0,
         "creator": null,
         "customProperties": {},
@@ -296,6 +307,7 @@
               "paletteIndex": null
             }
           ],
+          "noDataOptions": null,
           "time": {
             "range": 900000,
             "rangeEnd": 0,
@@ -311,98 +323,7 @@
     },
     {
       "chart": {
-        "created": 0,
-        "creator": null,
-        "customProperties": {},
-        "description": "Total number of jobs started",
-        "id": "FAZX0GnA4AM",
-        "lastUpdated": 0,
-        "lastUpdatedBy": null,
-        "name": "Jobs Started Sumarry",
-        "options": {
-          "areaChartOptions": {
-            "showDataMarkers": true
-          },
-          "axes": [
-            {
-              "highWatermark": null,
-              "highWatermarkLabel": null,
-              "label": "",
-              "lowWatermark": null,
-              "lowWatermarkLabel": null,
-              "max": null,
-              "min": null
-            },
-            {
-              "highWatermark": null,
-              "highWatermarkLabel": null,
-              "label": "",
-              "lowWatermark": null,
-              "lowWatermarkLabel": null,
-              "max": null,
-              "min": null
-            }
-          ],
-          "axisPrecision": null,
-          "colorBy": "Dimension",
-          "defaultPlotType": "LineChart",
-          "eventPublishLabelOptions": [
-            {
-              "displayName": "Build Buttercup Workflow Error Rate",
-              "label": "D",
-              "paletteIndex": null
-            }
-          ],
-          "histogramChartOptions": {
-            "colorThemeIndex": 16
-          },
-          "includeZero": false,
-          "legendOptions": {
-            "fields": null
-          },
-          "lineChartOptions": {
-            "showDataMarkers": true
-          },
-          "onChartLegendOptions": {
-            "dimensionInLegend": "sf_metric",
-            "showLegend": true
-          },
-          "programOptions": {
-            "disableSampling": false,
-            "maxDelay": 0,
-            "minimumResolution": 10000,
-            "timezone": null
-          },
-          "publishLabelOptions": [
-            {
-              "displayName": "Requests/sec",
-              "label": "C",
-              "paletteIndex": 11,
-              "plotType": null,
-              "valuePrefix": null,
-              "valueSuffix": "requests/s",
-              "valueUnit": null,
-              "yAxis": 0
-            }
-          ],
-          "showEventLines": true,
-          "stacked": false,
-          "time": {
-            "range": 900000,
-            "rangeEnd": 0,
-            "type": "relative"
-          },
-          "type": "TimeSeriesChart",
-          "unitPrefix": "Metric"
-        },
-        "packageSpecifications": "",
-        "programText": "C = data('service.request.count', filter=filter('sf_environment', '*') and filter('sf_service', '*') and (not filter('sf_dimensionalized', '*')), rollup='sum').sum(by=['sf_service', 'sf_environment']).publish(label='C')\nD = alerts(detector_name='Build Buttercup Workflow Error Rate').publish(label='D')",
-        "relatedDetectorIds": [],
-        "tags": null
-      }
-    },
-    {
-      "chart": {
+        "autoDetectRelatedDetectorIds": [],
         "created": 0,
         "creator": null,
         "customProperties": {},
@@ -410,7 +331,7 @@
         "id": "FAZX0GpA0AE",
         "lastUpdated": 0,
         "lastUpdatedBy": null,
-        "name": "Top endpoints by error rate (1h)",
+        "name": "Top Pipelines by error rate (1h)",
         "options": {
           "colorBy": "Dimension",
           "colorScale2": null,
@@ -444,6 +365,11 @@
             ]
           },
           "maximumPrecision": null,
+          "noDataOptions": {
+            "linkText": null,
+            "linkUrl": null,
+            "noDataMessage": null
+          },
           "programOptions": {
             "disableSampling": false,
             "maxDelay": 30000,
@@ -483,8 +409,8 @@
             }
           ],
           "refreshInterval": null,
-          "secondaryVisualization": "None",
-          "sortBy": "-value",
+          "secondaryVisualization": "Sparkline",
+          "sortBy": "",
           "time": {
             "range": 900000,
             "rangeEnd": 0,
@@ -501,6 +427,7 @@
     },
     {
       "chart": {
+        "autoDetectRelatedDetectorIds": [],
         "created": 0,
         "creator": null,
         "customProperties": {},
@@ -511,7 +438,7 @@
         "name": "Job Length by Pipeline",
         "options": {
           "areaChartOptions": {
-            "showDataMarkers": false
+            "showDataMarkers": true
           },
           "axes": [
             {
@@ -545,7 +472,12 @@
             "fields": null
           },
           "lineChartOptions": {
-            "showDataMarkers": false
+            "showDataMarkers": true
+          },
+          "noDataOptions": {
+            "linkText": null,
+            "linkUrl": null,
+            "noDataMessage": null
           },
           "onChartLegendOptions": {
             "dimensionInLegend": null,
@@ -569,7 +501,7 @@
               "yAxis": 0
             }
           ],
-          "showEventLines": false,
+          "showEventLines": true,
           "stacked": false,
           "time": {
             "range": 900000,
@@ -587,6 +519,7 @@
     },
     {
       "chart": {
+        "autoDetectRelatedDetectorIds": [],
         "created": 0,
         "creator": null,
         "customProperties": {},
@@ -594,7 +527,7 @@
         "id": "FAZX1_PA4AQ",
         "lastUpdated": 0,
         "lastUpdatedBy": null,
-        "name": "Pipeline Details (1d)",
+        "name": "Pipeline Summary (1d)",
         "options": {
           "colorBy": "Dimension",
           "colorScale2": null,
@@ -624,6 +557,7 @@
             ]
           },
           "maximumPrecision": 4,
+          "noDataOptions": null,
           "programOptions": {
             "disableSampling": true,
             "maxDelay": 30000,
@@ -681,6 +615,7 @@
     },
     {
       "chart": {
+        "autoDetectRelatedDetectorIds": [],
         "created": 0,
         "creator": null,
         "customProperties": {},
@@ -721,7 +656,12 @@
               }
             ]
           },
-          "maximumPrecision": 4,
+          "maximumPrecision": null,
+          "noDataOptions": {
+            "linkText": null,
+            "linkUrl": null,
+            "noDataMessage": null
+          },
           "programOptions": {
             "disableSampling": false,
             "maxDelay": 0,
@@ -741,8 +681,8 @@
             }
           ],
           "refreshInterval": null,
-          "secondaryVisualization": "None",
-          "sortBy": "-value",
+          "secondaryVisualization": "Sparkline",
+          "sortBy": "",
           "time": {
             "range": 3600000,
             "rangeEnd": 0,
@@ -759,6 +699,7 @@
     },
     {
       "chart": {
+        "autoDetectRelatedDetectorIds": [],
         "created": 0,
         "creator": null,
         "customProperties": {},
@@ -806,6 +747,7 @@
           "lineChartOptions": {
             "showDataMarkers": false
           },
+          "noDataOptions": null,
           "onChartLegendOptions": {
             "dimensionInLegend": null,
             "showLegend": false
@@ -875,70 +817,63 @@
           "column": 0,
           "height": 1,
           "row": 0,
-          "width": 4
+          "width": 5
         },
         {
           "chartId": "FAZXzyMA0AA",
-          "column": 8,
+          "column": 10,
           "height": 3,
           "row": 0,
-          "width": 4
-        },
-        {
-          "chartId": "FAZX1_PA4AQ",
-          "column": 4,
-          "height": 1,
-          "row": 0,
-          "width": 4
-        },
-        {
-          "chartId": "FAZX0GnA4AM",
-          "column": 0,
-          "height": 1,
-          "row": 1,
-          "width": 4
+          "width": 2
         },
         {
           "chartId": "FAZX04BA0AA",
-          "column": 4,
+          "column": 5,
+          "height": 1,
+          "row": 0,
+          "width": 5
+        },
+        {
+          "chartId": "FAZX1_PA4AQ",
+          "column": 0,
           "height": 1,
           "row": 1,
-          "width": 4
+          "width": 5
         },
         {
           "chartId": "FAZXm7dAwAQ",
-          "column": 4,
+          "column": 5,
           "height": 1,
-          "row": 2,
-          "width": 4
+          "row": 1,
+          "width": 5
         },
         {
           "chartId": "FAZg9_WA0AA",
           "column": 0,
           "height": 1,
           "row": 2,
-          "width": 4
+          "width": 5
+        },
+        {
+          "chartId": "FAZX0GpA0AE",
+          "column": 5,
+          "height": 1,
+          "row": 2,
+          "width": 5
         },
         {
           "chartId": "FAZXlLVAwAc",
           "column": 0,
           "height": 1,
           "row": 3,
-          "width": 4
+          "width": 5
         },
         {
           "chartId": "FAZcT6nA4AA",
-          "column": 4,
+          "column": 5,
           "height": 1,
           "row": 3,
-          "width": 4
-        },
-        {
-          "chartId": "FAZX0GpA0AE",
-          "column": 8,
-          "height": 1,
-          "row": 3,
-          "width": 4
+          "width": 5
         }
       ],
       "created": 0,
@@ -976,7 +911,7 @@
         "sources": null,
         "time": {
           "end": "Now",
-          "start": "-4h"
+          "start": "-6h"
         },
         "variables": [
           {
@@ -992,7 +927,7 @@
             "required": true,
             "restricted": false,
             "value": [
-              "Select Environment"
+              "*"
             ]
           },
           {
@@ -1008,7 +943,7 @@
             "required": true,
             "restricted": false,
             "value": [
-              "Select Service"
+              "*"
             ]
           },
           {
@@ -1024,32 +959,22 @@
             "required": false,
             "restricted": false,
             "value": [
-              "Select Pipeline"
+              "*"
             ]
           }
         ]
       },
-      "groupId": "E8ePvoTA0AE",
       "id": "FAZX1_PA4AU",
       "lastUpdated": 0,
       "lastUpdatedBy": null,
       "maxDelayOverride": null,
       "name": "Jenkins-APM-Service-Endpoints",
-      "selectedEventOverlays": [
-        {
-          "eventSignal": {
-            "detectorId": null,
-            "eventSearchText": "*Select detector*",
-            "eventType": "eventTimeSeries"
-          },
-          "overlayId": null,
-          "sources": []
-        }
-      ],
+      "permissions": null,
+      "selectedEventOverlays": [],
       "tags": null
     }
   },
-  "hashCode": -550392347,
+  "hashCode": -833068008,
   "id": "FAZX1_PA4AU",
   "modelVersion": 1,
   "packageType": "DASHBOARD"

--- a/dashboards/dashboard_Jenkins-Health-Overview (OTEL Span Metricization).json
+++ b/dashboards/dashboard_Jenkins-Health-Overview (OTEL Span Metricization).json
@@ -2,6 +2,7 @@
   "chartExports": [
     {
       "chart": {
+        "autoDetectRelatedDetectorIds": [],
         "created": 0,
         "creator": null,
         "customProperties": {},
@@ -15,6 +16,7 @@
           "colorScale": null,
           "colorScale2": null,
           "maximumPrecision": null,
+          "noDataOptions": null,
           "programOptions": {
             "disableSampling": false,
             "maxDelay": 0,
@@ -53,6 +55,7 @@
     },
     {
       "chart": {
+        "autoDetectRelatedDetectorIds": [],
         "created": 0,
         "creator": null,
         "customProperties": {},
@@ -66,6 +69,11 @@
           "colorScale": null,
           "colorScale2": null,
           "maximumPrecision": null,
+          "noDataOptions": {
+            "linkText": null,
+            "linkUrl": null,
+            "noDataMessage": null
+          },
           "programOptions": {
             "disableSampling": false,
             "maxDelay": 0,
@@ -97,13 +105,14 @@
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('jenkins.run.status', filter=filter('environment', '*') and filter('service.name', '*'), rollup='count').sum(over='1d').sum().publish(label='A')",
+        "programText": "A = data('spans.count', filter=filter('environment', '*') and filter('service.name', '*')).sum(by=['sf_operation']).sum(over='1d').publish(label='A')",
         "relatedDetectorIds": [],
         "tags": null
       }
     },
     {
       "chart": {
+        "autoDetectRelatedDetectorIds": [],
         "created": 0,
         "creator": null,
         "customProperties": {},
@@ -117,6 +126,7 @@
           "colorScale": null,
           "colorScale2": null,
           "maximumPrecision": null,
+          "noDataOptions": null,
           "programOptions": {
             "disableSampling": false,
             "maxDelay": 0,
@@ -155,6 +165,7 @@
     },
     {
       "chart": {
+        "autoDetectRelatedDetectorIds": [],
         "created": 0,
         "creator": null,
         "customProperties": {},
@@ -168,6 +179,11 @@
           "colorScale": null,
           "colorScale2": null,
           "maximumPrecision": null,
+          "noDataOptions": {
+            "linkText": null,
+            "linkUrl": null,
+            "noDataMessage": null
+          },
           "programOptions": {
             "disableSampling": false,
             "maxDelay": 0,
@@ -199,13 +215,14 @@
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('jenkins.run.status', filter=filter('status.code', 'STATUS_CODE_ERROR') and filter('environment', '*') and filter('service.name', '*'), rollup='count').sum(over='1d').sum().publish(label='A')",
+        "programText": "A = data('spans.count', filter=filter('environment', '*') and filter('service.name', '*') and filter('sf_error', 'true')).sum(by=['sf_operation']).sum(over='1d').publish(label='A')",
         "relatedDetectorIds": [],
         "tags": null
       }
     },
     {
       "chart": {
+        "autoDetectRelatedDetectorIds": [],
         "created": 0,
         "creator": null,
         "customProperties": {},
@@ -219,6 +236,7 @@
           "colorScale": null,
           "colorScale2": null,
           "maximumPrecision": null,
+          "noDataOptions": null,
           "programOptions": {
             "disableSampling": false,
             "maxDelay": 0,
@@ -257,6 +275,7 @@
     },
     {
       "chart": {
+        "autoDetectRelatedDetectorIds": [],
         "created": 0,
         "creator": null,
         "customProperties": {},
@@ -298,14 +317,48 @@
           },
           "includeZero": false,
           "legendOptions": {
-            "fields": null
+            "fields": [
+              {
+                "enabled": false,
+                "property": "status.code"
+              },
+              {
+                "enabled": true,
+                "property": "ci.pipeline.id"
+              },
+              {
+                "enabled": false,
+                "property": "sf_originatingMetric"
+              },
+              {
+                "enabled": true,
+                "property": "sf_metric"
+              },
+              {
+                "enabled": false,
+                "property": "jenkins.pipeline.step.name"
+              },
+              {
+                "enabled": false,
+                "property": "sf_error"
+              },
+              {
+                "enabled": true,
+                "property": "sf_operation"
+              }
+            ]
           },
           "lineChartOptions": {
             "showDataMarkers": false
           },
+          "noDataOptions": {
+            "linkText": null,
+            "linkUrl": null,
+            "noDataMessage": null
+          },
           "onChartLegendOptions": {
-            "dimensionInLegend": "status.code",
-            "showLegend": true
+            "dimensionInLegend": null,
+            "showLegend": false
           },
           "programOptions": {
             "disableSampling": false,
@@ -315,9 +368,19 @@
           },
           "publishLabelOptions": [
             {
-              "displayName": "A",
+              "displayName": "Failed",
               "label": "A",
-              "paletteIndex": null,
+              "paletteIndex": 4,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "Succeeded",
+              "label": "C",
+              "paletteIndex": 3,
               "plotType": null,
               "valuePrefix": null,
               "valueSuffix": null,
@@ -336,13 +399,14 @@
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('jenkins.run.status', filter=filter('environment', '*') and filter('service.name', '*'), rollup='count').sum(by=['status.code']).publish(label='A')",
+        "programText": "A = data('spans.count', filter=filter('sf_error', 'true') and filter('environment', '*') and filter('service.name', '*')).sum(by=['sf_error', 'sf_operation']).publish(label='A')\nC = data('spans.count', filter=filter('sf_error', 'false') and filter('environment', '*') and filter('service.name', '*')).sum(by=['sf_error', 'sf_operation']).publish(label='C')",
         "relatedDetectorIds": [],
         "tags": null
       }
     },
     {
       "chart": {
+        "autoDetectRelatedDetectorIds": [],
         "created": 0,
         "creator": null,
         "customProperties": {},
@@ -356,6 +420,7 @@
           "colorScale": null,
           "colorScale2": null,
           "maximumPrecision": null,
+          "noDataOptions": null,
           "programOptions": {
             "disableSampling": false,
             "maxDelay": 0,
@@ -394,6 +459,7 @@
     },
     {
       "chart": {
+        "autoDetectRelatedDetectorIds": [],
         "created": 0,
         "creator": null,
         "customProperties": {},
@@ -407,6 +473,7 @@
           "colorScale": null,
           "colorScale2": null,
           "maximumPrecision": null,
+          "noDataOptions": null,
           "programOptions": {
             "disableSampling": false,
             "maxDelay": 0,
@@ -445,6 +512,7 @@
     },
     {
       "chart": {
+        "autoDetectRelatedDetectorIds": [],
         "created": 0,
         "creator": null,
         "customProperties": {},
@@ -458,6 +526,7 @@
           "colorScale": null,
           "colorScale2": null,
           "maximumPrecision": null,
+          "noDataOptions": null,
           "programOptions": {
             "disableSampling": false,
             "maxDelay": 0,
@@ -496,6 +565,7 @@
     },
     {
       "chart": {
+        "autoDetectRelatedDetectorIds": [],
         "created": 0,
         "creator": null,
         "customProperties": {},
@@ -509,6 +579,7 @@
           "colorScale": null,
           "colorScale2": null,
           "maximumPrecision": null,
+          "noDataOptions": null,
           "programOptions": {
             "disableSampling": false,
             "maxDelay": 0,
@@ -547,6 +618,7 @@
     },
     {
       "chart": {
+        "autoDetectRelatedDetectorIds": [],
         "created": 0,
         "creator": null,
         "customProperties": {},
@@ -593,6 +665,7 @@
           "lineChartOptions": {
             "showDataMarkers": false
           },
+          "noDataOptions": null,
           "onChartLegendOptions": {
             "dimensionInLegend": null,
             "showLegend": false
@@ -633,6 +706,7 @@
     },
     {
       "chart": {
+        "autoDetectRelatedDetectorIds": [],
         "created": 0,
         "creator": null,
         "customProperties": {},
@@ -658,10 +732,43 @@
               {
                 "enabled": false,
                 "property": "sf_metric"
+              },
+              {
+                "enabled": true,
+                "property": "service.name"
+              },
+              {
+                "enabled": true,
+                "property": "jenkins.pipeline.step.name"
+              },
+              {
+                "enabled": true,
+                "property": "status.code"
+              },
+              {
+                "enabled": true,
+                "property": "span.kind"
+              },
+              {
+                "enabled": true,
+                "property": "jenkins.pipeline.step.type"
+              },
+              {
+                "enabled": true,
+                "property": "operation"
+              },
+              {
+                "enabled": true,
+                "property": "ci.pipeline.id"
               }
             ]
           },
           "maximumPrecision": null,
+          "noDataOptions": {
+            "linkText": null,
+            "linkUrl": null,
+            "noDataMessage": null
+          },
           "programOptions": {
             "disableSampling": false,
             "maxDelay": 0,
@@ -670,7 +777,17 @@
           },
           "publishLabelOptions": [
             {
-              "displayName": "jenkins.pipeline.step.status - Sum by attributes.jenkins.pipeline.step.type - Sum(1h)",
+              "displayName": "jenkins.calls_total - Sum(1h) - Sum by jenkins.pipeline.step.name",
+              "label": "B",
+              "paletteIndex": null,
+              "plotType": null,
+              "valuePrefix": null,
+              "valueSuffix": null,
+              "valueUnit": null,
+              "yAxis": 0
+            },
+            {
+              "displayName": "jenkins.calls - Sum(1h) - Sum by jenkins.pipeline.step.name",
               "label": "A",
               "paletteIndex": null,
               "plotType": null,
@@ -692,13 +809,14 @@
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('jenkins.pipeline.step.status', filter=filter('environment', '*') and filter('service.name', '*')).sum(by=['attributes.jenkins.pipeline.step.type']).sum(over='1h').publish(label='A')",
+        "programText": "B = data('jenkins.calls_total').sum(over='1h').sum(by=['jenkins.pipeline.step.name']).publish(label='B')\nA = data('jenkins.calls').sum(over='1h').sum(by=['jenkins.pipeline.step.name']).publish(label='A')",
         "relatedDetectorIds": [],
         "tags": null
       }
     },
     {
       "chart": {
+        "autoDetectRelatedDetectorIds": [],
         "created": 0,
         "creator": null,
         "customProperties": {},
@@ -724,10 +842,19 @@
               {
                 "enabled": false,
                 "property": "sf_metric"
+              },
+              {
+                "enabled": true,
+                "property": "jenkins.pipeline.step.name"
               }
             ]
           },
           "maximumPrecision": null,
+          "noDataOptions": {
+            "linkText": null,
+            "linkUrl": null,
+            "noDataMessage": null
+          },
           "programOptions": {
             "disableSampling": false,
             "maxDelay": 0,
@@ -758,13 +885,14 @@
           "unitPrefix": "Metric"
         },
         "packageSpecifications": "",
-        "programText": "A = data('jenkins.pipeline.step.status', filter=filter('environment', '*') and filter('service.name', '*') and filter('status.code', 'STATUS_CODE_ERROR')).sum(by=['attributes.jenkins.pipeline.step.type']).sum(over='1h').publish(label='A')",
+        "programText": "A = data('jenkins.calls', filter=filter('status.code', 'STATUS_CODE_ERROR')).sum(over='1h').sum(by=['jenkins.pipeline.step.name']).top(count=10).publish(label='A')",
         "relatedDetectorIds": [],
         "tags": null
       }
     },
     {
       "chart": {
+        "autoDetectRelatedDetectorIds": [],
         "created": 0,
         "creator": null,
         "customProperties": {},
@@ -892,6 +1020,7 @@
           "lineChartOptions": {
             "showDataMarkers": false
           },
+          "noDataOptions": null,
           "onChartLegendOptions": {
             "dimensionInLegend": null,
             "showLegend": false
@@ -1043,7 +1172,10 @@
       "eventOverlays": null,
       "filters": {
         "sources": null,
-        "time": null,
+        "time": {
+          "end": "Now",
+          "start": "-6h"
+        },
         "variables": [
           {
             "alias": "environment",
@@ -1058,7 +1190,7 @@
             "required": true,
             "restricted": false,
             "value": [
-              "Select Environment"
+              "*"
             ]
           },
           {
@@ -1074,22 +1206,22 @@
             "required": true,
             "restricted": false,
             "value": [
-              "Select your Service"
+              "*"
             ]
           }
         ]
       },
-      "groupId": "E8ePvoTA0AE",
       "id": "FBHnR2iA0AA",
       "lastUpdated": 0,
       "lastUpdatedBy": null,
       "maxDelayOverride": null,
       "name": "Jenkins-Health-Overview",
+      "permissions": null,
       "selectedEventOverlays": [],
       "tags": null
     }
   },
-  "hashCode": 941139386,
+  "hashCode": 867714956,
   "id": "FBHnR2iA0AA",
   "modelVersion": 1,
   "packageType": "DASHBOARD"

--- a/dashboards/terraform-dashboards/Jenkins-APM-Service-Endpoint.tf
+++ b/dashboards/terraform-dashboards/Jenkins-APM-Service-Endpoint.tf
@@ -1,0 +1,498 @@
+resource "signalfx_dashboard" "Jenkins-APM-Service-Endpoint" {
+    name                = "Jenkins-APM-Service-Endpoints"
+    description         = "Service-level indicators from APM Tracing Metrics"
+    dashboard_group     = signalfx_dashboard_group.jenkins-apm.id
+    charts_resolution    = "default"
+    time_range = "-24h"
+
+    chart {
+      chart_id = signalfx_list_chart.F1Ugj3-AwAQ.id
+      column = "0"
+      height = "1"
+      row = "0"
+      width = "6"
+    }
+    chart {
+      chart_id = signalfx_time_chart.F1Ugj3-AwAE.id
+      column = "6"
+      height = "1"
+      row = "0"
+      width = "6"
+    }
+    chart {
+      chart_id = signalfx_list_chart.F1Ugj3-AwAI.id
+      column = "0"
+      height = "1"
+      row = "1"
+      width = "6"
+    }
+    chart {
+      chart_id = signalfx_time_chart.F1UbZxwA4AA.id
+      column = "6"
+      height = "1"
+      row = "1"
+      width = "6"
+    }
+    chart {
+      chart_id = signalfx_time_chart.F1Ugj3-AwAA.id
+      column = "0"
+      height = "1"
+      row = "2"
+      width = "6"
+    }
+    chart {
+      chart_id = signalfx_list_chart.F1Ugj3-AwAU.id
+      column = "6"
+      height = "1"
+      row = "2"
+      width = "6"
+    }
+    chart {
+      chart_id = signalfx_list_chart.F1Ugj3-AwAM.id
+      column = "0"
+      height = "1"
+      row = "3"
+      width = "6"
+    }
+    chart {
+      chart_id = signalfx_list_chart.F1Ugj3-AwAY.id
+      column = "6"
+      height = "1"
+      row = "3"
+      width = "6"
+    }
+
+    variable {
+      alias = "Environment"
+      apply_if_exist = "false"
+      description = "APM Environment Name"
+      property = "sf_environment"
+      replace_only = "false"
+      value_required = "true"
+      restricted_suggestions = "false"
+      values =  ["*"]
+    }
+    variable {
+      alias = "Service"
+      apply_if_exist = "false"
+      description = "APM Service Name"
+      property = "sf_service"
+      replace_only = "true"
+      value_required = "true"
+      restricted_suggestions = "false"
+      values =  ["*"]
+    }
+    variable {
+      alias = "Pipeline"
+      apply_if_exist = "false"
+      description = ""
+      property = "sf_operation"
+      replace_only = "true"
+      value_required = "false"
+      restricted_suggestions = "false"
+      values =  ["*"]
+    }
+}
+
+## ChartID: signalfx_list_chart.F1Ugj3-AwAQ.id
+resource "signalfx_list_chart" "F1Ugj3-AwAQ" {
+    name                = "Pipeline Summary (1d)"
+    color_by            = "Metric"
+    max_precision       = 4
+
+    unit_prefix         = "Metric"
+    secondary_visualization = "Sparkline"
+
+    viz_options {
+      label = "Error Rate"
+      display_name = "Error Rate"
+      value_suffix = "%"
+    }
+
+    viz_options {
+      label = "Jobs Failed"
+      display_name = "Jobs Failed"
+    }
+
+    viz_options {
+      label = "Jobs Total"
+      display_name = "Jobs Total"
+    }
+
+    legend_options_fields {
+      enabled         = false
+      property        = "sf_originatingMetric"
+    }
+
+    legend_options_fields {
+      enabled         = true
+      property        = "sf_metric"
+    }
+
+    legend_options_fields {
+      enabled         = true
+      property        = "sf_environment"
+    }
+
+    legend_options_fields {
+      enabled         = true
+      property        = "sf_error"
+    }
+
+    legend_options_fields {
+      enabled         = true
+      property        = "sf_service"
+    }
+
+
+    program_text = <<-EOF
+A = data('spans.count', filter=filter('sf_environment', '*') and filter('sf_service', '*'), rollup='sum').sum(by=['sf_service']).sum(over='1d').publish(label='Jobs Total')
+B = data('spans.count', filter=filter('sf_environment', '*') and filter('sf_service', '*') and filter('sf_error', 'true'), rollup='sum').sum(by=['sf_service']).sum(over='1d').publish(label='Jobs Failed')
+C = (100*(B/A)).mean(over='1d').publish(label='Error Rate')
+    EOF
+}
+
+## ChartID: signalfx_time_chart.F1Ugj3-AwAE.id
+resource "signalfx_time_chart" "F1Ugj3-AwAE" {
+    name                = "Pipeline Length"
+    description         = "Pipeline Length"
+    plot_type           = "LineChart"
+    unit_prefix         = "Metric"
+    color_by            = "Dimension"
+    minimum_resolution  = 10000
+    disable_sampling    = true
+  
+
+    viz_options {
+      label = "p90"
+      value_unit = "Nanosecond"
+    }
+
+    histogram_options {
+      color_theme = "red"
+    }
+
+
+    show_event_lines    = true
+    show_data_markers = true
+
+    program_text = <<-EOF
+def weighted_duration(base, p, filter_, groupby):
+    error_durations     = data(base + '.duration.ns.' + p, filter=filter_ and filter('sf_error', 'true'),  rollup='max').mean(by=groupby, allow_missing=['sf_httpMethod'])
+    non_error_durations = data(base + '.duration.ns.' + p, filter=filter_ and filter('sf_error', 'false'), rollup='max').mean(by=groupby, allow_missing=['sf_httpMethod'])
+
+    error_counts     = data(base + '.count', filter=filter_ and filter('sf_error', 'true'),  rollup='sum').sum(by=groupby, allow_missing=['sf_httpMethod'])
+    non_error_counts = data(base + '.count', filter=filter_ and filter('sf_error', 'false'), rollup='sum').sum(by=groupby, allow_missing=['sf_httpMethod'])
+
+    error_weight     = (error_durations * error_counts).sum(over='1m')
+    non_error_weight = (non_error_durations * non_error_counts).sum(over='1m')
+
+    total_weight = combine((error_weight if error_weight is not None else 0) + (non_error_weight if non_error_weight is not None else 0))
+    total = combine((error_counts if error_counts is not None else 0) + (non_error_counts if non_error_counts is not None else 0)).sum(over='1m')
+    return (total_weight / total)
+
+filter_ = filter('sf_environment', '*') and filter('sf_service', '*') and filter('sf_operation', '*') and filter('sf_kind', 'SERVER', 'CONSUMER') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*'))
+groupby = ['sf_service', 'sf_environment', 'sf_operation', 'sf_httpMethod']
+weighted_duration('spans', 'p90', filter_, groupby).publish(label='p90')
+    EOF
+}
+
+## ChartID: signalfx_list_chart.F1Ugj3-AwAI.id
+resource "signalfx_list_chart" "F1Ugj3-AwAI" {
+    name                = "Pipeline Summary By Environment (1d)"
+    color_by            = "Dimension"
+    max_precision       = 4
+    disable_sampling    = true
+
+    unit_prefix         = "Metric"
+    secondary_visualization = "Sparkline"
+
+    viz_options {
+      label = "Error Rate"
+      display_name = "Error Rate"
+      value_suffix = "%"
+    }
+
+    viz_options {
+      label = "Runs Failed"
+      display_name = "Runs Failed"
+    }
+
+    viz_options {
+      label = "Runs Total"
+      display_name = "Runs Total"
+    }
+
+    legend_options_fields {
+      enabled         = false
+      property        = "sf_originatingMetric"
+    }
+
+    legend_options_fields {
+      enabled         = true
+      property        = "sf_environment"
+    }
+
+    legend_options_fields {
+      enabled         = false
+      property        = "sf_operation"
+    }
+
+    legend_options_fields {
+      enabled         = false
+      property        = "sf_service"
+    }
+
+    legend_options_fields {
+      enabled         = true
+      property        = "sf_metric"
+    }
+
+
+    program_text = <<-EOF
+filter_ = filter('sf_environment', '*') and filter('sf_service', '*') and filter('sf_operation', '*') and filter('sf_kind', 'SERVER', 'CONSUMER') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*'))
+filter_errors = filter('sf_environment', '*') and filter('sf_service', '*') and filter('sf_operation', '*') and filter('sf_error', 'true') and filter('sf_kind', 'SERVER', 'CONSUMER') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*'))
+A = data('spans.count', filter=filter_, extrapolation='null').sum(over='1d').sum(by=['sf_environment']).publish(label='Runs Total')
+B = data('spans.count', filter=filter_errors, extrapolation='null').sum(over='1d').sum(by=['sf_environment']).publish(label='Runs Failed')
+C = (100*(B/A)).sum(by=['sf_environment']).publish(label='Error Rate')
+    EOF
+}
+
+## ChartID: signalfx_time_chart.F1UbZxwA4AA.id
+resource "signalfx_time_chart" "F1UbZxwA4AA" {
+    name                = "Failure Rate (%) by Pipeline"
+    description         = "Failure Rate (%) by Pipeline"
+    plot_type           = "LineChart"
+    unit_prefix         = "Metric"
+    color_by            = "Dimension"
+    minimum_resolution  = 10000
+    disable_sampling    = true
+  
+
+    viz_options {
+      label = "A"
+    }
+    viz_options {
+      label = "B"
+    }
+    viz_options {
+      label = "C"
+      value_suffix = "%"
+    }
+
+    histogram_options {
+      color_theme = "red"
+    }
+
+
+    show_event_lines    = false
+
+    program_text = <<-EOF
+filter_ = filter('sf_environment', '*') and filter('sf_service', '*') and filter('sf_kind', 'SERVER', 'CONSUMER') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*'))
+A = data('spans.count', filter=filter_ and filter('sf_error', 'true'), rollup='rate').sum(by=['sf_environment', 'sf_service', 'sf_operation', 'sf_httpMethod'], allow_missing=['sf_httpMethod']).publish(label='A', enable=False)
+B = data('spans.count', filter=filter_, rollup='rate').sum(by=['sf_environment', 'sf_service', 'sf_operation', 'sf_httpMethod'], allow_missing=['sf_httpMethod']).publish(label='B', enable=False)
+C = combine(100*((A if A is not None else 0)/B)).publish(label='C')
+    EOF
+}
+
+## ChartID: signalfx_time_chart.F1Ugj3-AwAA.id
+resource "signalfx_time_chart" "F1Ugj3-AwAA" {
+    name                = "Error Rate Summary"
+    description         = "Total error rate for all jobs"
+    plot_type           = "LineChart"
+    unit_prefix         = "Metric"
+    color_by            = "Dimension"
+    minimum_resolution  = 10000
+  
+
+    viz_options {
+      label = "A"
+    }
+    viz_options {
+      label = "B"
+    }
+    viz_options {
+      label = "C"
+      color = "pink"
+      value_suffix = "%"
+    }
+
+    histogram_options {
+      color_theme = "red"
+    }
+
+
+    show_event_lines    = false
+
+    program_text = <<-EOF
+filter_ = filter('sf_environment', '*') and filter('sf_service', '*') and (not filter('sf_dimensionalized', '*'))
+A = data('service.request.count', filter=filter_ and filter('sf_error', 'true'), rollup='delta').sum(by=['sf_environment', 'sf_service']).publish(label='A', enable=False)
+B = data('service.request.count', filter=filter_, rollup='delta').sum(by=['sf_environment', 'sf_service']).publish(label='B', enable=False)
+C = combine(100*((A if A is not None else 0) / B)).publish(label='C')
+    EOF
+}
+
+## ChartID: signalfx_list_chart.F1Ugj3-AwAU.id
+resource "signalfx_list_chart" "F1Ugj3-AwAU" {
+    name                = "Top Pipelines by error rate (1d)"
+    description         = "Most erroneous service endpoints (1 day error rate average)"
+    color_by            = "Dimension"
+
+    unit_prefix         = "Metric"
+    secondary_visualization = "Sparkline"
+
+    viz_options {
+      label = "C"
+      value_suffix = "%"
+    }
+
+    legend_options_fields {
+      enabled         = false
+      property        = "sf_originatingMetric"
+    }
+
+    legend_options_fields {
+      enabled         = false
+      property        = "sf_metric"
+    }
+
+    legend_options_fields {
+      enabled         = false
+      property        = "sf_environment"
+    }
+
+    legend_options_fields {
+      enabled         = true
+      property        = "sf_operation"
+    }
+
+    legend_options_fields {
+      enabled         = true
+      property        = "sf_httpMethod"
+    }
+
+    legend_options_fields {
+      enabled         = true
+      property        = "sf_service"
+    }
+
+
+    program_text = <<-EOF
+filter_ = filter('sf_environment', '*') and filter('sf_service', '*') and filter('sf_kind', 'SERVER', 'CONSUMER') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*'))
+A = data('spans.count', filter=filter_ and filter('sf_error', 'true'), rollup='rate').sum(by=['sf_environment', 'sf_service', 'sf_operation', 'sf_httpMethod'], allow_missing=['sf_httpMethod']).sum(over='1d').publish(label='A', enable=False)
+B = data('spans.count', filter=filter_, rollup='rate').sum(by=['sf_environment', 'sf_service', 'sf_operation', 'sf_httpMethod'], allow_missing=['sf_httpMethod']).sum(over='1d').publish(label='B', enable=False)
+C = combine(100*((A if A is not None else 0)/B)).mean(over='1m').top(count=10).publish(label='C')
+    EOF
+}
+
+## ChartID: signalfx_list_chart.F1Ugj3-AwAM.id
+resource "signalfx_list_chart" "F1Ugj3-AwAM" {
+    name                = "Top pipelines by Jobs (1d)"
+    description         = "Top pipelines by number of Jobs"
+    color_by            = "Dimension"
+
+    unit_prefix         = "Metric"
+    secondary_visualization = "Sparkline"
+
+    legend_options_fields {
+      enabled         = false
+      property        = "sf_originatingMetric"
+    }
+
+    legend_options_fields {
+      enabled         = false
+      property        = "sf_metric"
+    }
+
+    legend_options_fields {
+      enabled         = false
+      property        = "sf_environment"
+    }
+
+    legend_options_fields {
+      enabled         = true
+      property        = "sf_operation"
+    }
+
+    legend_options_fields {
+      enabled         = true
+      property        = "sf_httpMethod"
+    }
+
+    legend_options_fields {
+      enabled         = true
+      property        = "sf_service"
+    }
+
+
+    program_text = <<-EOF
+filter_ = filter('sf_environment', '*') and filter('sf_service', '*') and filter('sf_operation', '*') and filter('sf_kind', 'SERVER', 'CONSUMER') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*'))
+A = data('spans.count', filter=filter_, rollup='sum', extrapolation='last_value').sum(by=['sf_environment', 'sf_service', 'sf_operation', 'sf_httpMethod'], allow_missing=['sf_httpMethod']).sum(over='1d').top(count=10).publish(label='A')
+    EOF
+}
+
+## ChartID: signalfx_list_chart.F1Ugj3-AwAY.id
+resource "signalfx_list_chart" "F1Ugj3-AwAY" {
+    name                = "Top pipelines by job length (1d)"
+    description         = "Top pipelines by job length"
+    color_by            = "Dimension"
+
+    unit_prefix         = "Metric"
+    secondary_visualization = "Sparkline"
+
+    viz_options {
+      label = "p90"
+      value_unit = "Nanosecond"
+    }
+
+    legend_options_fields {
+      enabled         = false
+      property        = "sf_originatingMetric"
+    }
+
+    legend_options_fields {
+      enabled         = false
+      property        = "sf_metric"
+    }
+
+    legend_options_fields {
+      enabled         = false
+      property        = "sf_environment"
+    }
+
+    legend_options_fields {
+      enabled         = true
+      property        = "sf_operation"
+    }
+
+    legend_options_fields {
+      enabled         = false
+      property        = "sf_httpMethod"
+    }
+
+    legend_options_fields {
+      enabled         = true
+      property        = "sf_service"
+    }
+
+
+    program_text = <<-EOF
+def weighted_duration(base, p, filter_, groupby):
+    error_durations     = data(base + '.duration.ns.' + p, filter=filter_ and filter('sf_error', 'true'),  rollup='max').mean(by=groupby, allow_missing=['sf_httpMethod'])
+    non_error_durations = data(base + '.duration.ns.' + p, filter=filter_ and filter('sf_error', 'false'), rollup='max').mean(by=groupby, allow_missing=['sf_httpMethod'])
+
+    error_counts     = data(base + '.count', filter=filter_ and filter('sf_error', 'true'),  rollup='sum').sum(by=groupby, allow_missing=['sf_httpMethod'])
+    non_error_counts = data(base + '.count', filter=filter_ and filter('sf_error', 'false'), rollup='sum').sum(by=groupby, allow_missing=['sf_httpMethod'])
+
+    error_weight     = (error_durations * error_counts)
+    non_error_weight = (non_error_durations * non_error_counts)
+
+    total_weight = combine((error_weight if error_weight is not None else 0) + (non_error_weight if non_error_weight is not None else 0))
+    total = combine((error_counts if error_counts is not None else 0) + (non_error_counts if non_error_counts is not None else 0)).sum(over='1h')
+    return (total_weight / total)
+
+filter_ = filter('sf_environment', '*') and filter('sf_service', '*') and filter('sf_operation', '*') and filter('sf_kind', 'SERVER', 'CONSUMER') and (not filter('sf_dimensionalized', '*')) and (not filter('sf_serviceMesh', '*'))
+groupby = ['sf_service', 'sf_environment', 'sf_operation', 'sf_httpMethod']
+weighted_duration('spans', 'p90', filter_, groupby).mean(over='1d').publish(label='p90')
+    EOF
+}

--- a/dashboards/terraform-dashboards/Jenkins-Health-Overview.tf
+++ b/dashboards/terraform-dashboards/Jenkins-Health-Overview.tf
@@ -1,0 +1,525 @@
+resource "signalfx_dashboard" "Jenkins-Health-Overview" {
+    name                = "Jenkins-Health-Overview"
+    dashboard_group     = signalfx_dashboard_group.jenkins-apm.id
+    charts_resolution    = "default"
+    time_range = "-24h"
+
+    chart {
+      chart_id = signalfx_single_value_chart.FBHnZJSA4AA.id
+      column = "6"
+      height = "1"
+      row = "0"
+      width = "2"
+    }
+    chart {
+      chart_id = signalfx_single_value_chart.FBHnQgYA0AI.id
+      column = "8"
+      height = "1"
+      row = "0"
+      width = "2"
+    }
+    chart {
+      chart_id = signalfx_single_value_chart.FBHnQQIA0AE.id
+      column = "10"
+      height = "1"
+      row = "0"
+      width = "2"
+    }
+    chart {
+      chart_id = signalfx_single_value_chart.FBHnQgYAwAQ.id
+      column = "4"
+      height = "1"
+      row = "0"
+      width = "2"
+    }
+    chart {
+      chart_id = signalfx_single_value_chart.FBHuAuMA0AA.id
+      column = "0"
+      height = "1"
+      row = "0"
+      width = "2"
+    }
+    chart {
+      chart_id = signalfx_single_value_chart.FBHtz54AwAA.id
+      column = "2"
+      height = "1"
+      row = "0"
+      width = "2"
+    }
+    chart {
+      chart_id = signalfx_single_value_chart.FBHncuWA0AE.id
+      column = "8"
+      height = "1"
+      row = "1"
+      width = "2"
+    }
+    chart {
+      chart_id = signalfx_time_chart.FBHtToXA0AE.id
+      column = "4"
+      height = "1"
+      row = "1"
+      width = "4"
+    }
+    chart {
+      chart_id = signalfx_single_value_chart.FBHuYJdA4AA.id
+      column = "0"
+      height = "1"
+      row = "1"
+      width = "2"
+    }
+    chart {
+      chart_id = signalfx_single_value_chart.FBHuIvZA0AA.id
+      column = "2"
+      height = "1"
+      row = "1"
+      width = "2"
+    }
+    chart {
+      chart_id = signalfx_time_chart.FBHvQ1JA0AE.id
+      column = "10"
+      height = "1"
+      row = "1"
+      width = "2"
+    }
+    chart {
+      chart_id = signalfx_time_chart.FBH3Uh5A0AA.id
+      column = "0"
+      height = "1"
+      row = "2"
+      width = "4"
+    }
+    chart {
+      chart_id = signalfx_list_chart.FBH0_MVAwAA.id
+      column = "4"
+      height = "1"
+      row = "2"
+      width = "4"
+    }
+    chart {
+      chart_id = signalfx_list_chart.FBH3M7vA0AA.id
+      column = "8"
+      height = "1"
+      row = "2"
+      width = "4"
+    }
+
+    variable {
+      alias = "environment"
+      apply_if_exist = "true"
+      description = ""
+      property = "environment"
+      replace_only = "true"
+      value_required = "true"
+      restricted_suggestions = "false"
+      values =  ["*"]
+    }
+    variable {
+      alias = "service.name"
+      apply_if_exist = "true"
+      description = ""
+      property = "service.name"
+      replace_only = "true"
+      value_required = "true"
+      restricted_suggestions = "false"
+      values =  ["*"]
+    }
+}
+
+resource "signalfx_single_value_chart" "FBHnZJSA4AA" {
+    name                = "Total Failed Jobs (1d)"
+    color_by            = "Dimension"
+    is_timestamp_hidden = false
+    show_spark_line     = false
+    unit_prefix         = "Metric"
+    secondary_visualization = "None"
+
+    program_text = <<-EOF
+A = data('spans.count', filter=filter('environment', '*') and filter('service.name', '*') and filter('sf_error', 'true')).sum(by=['sf_operation']).sum(over='1d').publish(label='A')
+    EOF
+}
+
+resource "signalfx_single_value_chart" "FBHnQgYA0AI" {
+    name                = "Total Agents"
+    color_by            = "Dimension"
+    is_timestamp_hidden = false
+    show_spark_line     = false
+    unit_prefix         = "Metric"
+    secondary_visualization = "None"
+
+    program_text = <<-EOF
+A = data('jenkins.agents.total', filter=filter('environment', '*') and filter('service.name', '*')).publish(label='A')
+    EOF
+}
+
+resource "signalfx_single_value_chart" "FBHnQQIA0AE" {
+    name                = "Agents Online"
+    color_by            = "Dimension"
+    is_timestamp_hidden = false
+    show_spark_line     = false
+    unit_prefix         = "Metric"
+    secondary_visualization = "None"
+
+    program_text = <<-EOF
+A = data('jenkins.agents.online', filter=filter('environment', '*') and filter('service.name', '*')).publish(label='A')
+    EOF
+}
+
+resource "signalfx_single_value_chart" "FBHnQgYAwAQ" {
+    name                = "Total Jobs (1d)"
+    color_by            = "Dimension"
+    is_timestamp_hidden = false
+    show_spark_line     = false
+    unit_prefix         = "Metric"
+    secondary_visualization = "None"
+
+    program_text = <<-EOF
+A = data('spans.count', filter=filter('environment', '*') and filter('service.name', '*')).sum(by=['sf_operation']).sum(over='1d').publish(label='A')
+    EOF
+}
+
+resource "signalfx_single_value_chart" "FBHuAuMA0AA" {
+    name                = "Build Queue"
+    color_by            = "Dimension"
+    is_timestamp_hidden = false
+    show_spark_line     = false
+    unit_prefix         = "Metric"
+    secondary_visualization = "None"
+
+    program_text = <<-EOF
+A = data('jenkins.queue.waiting', filter=filter('environment', '*') and filter('service.name', '*')).publish(label='A')
+    EOF
+}
+
+resource "signalfx_single_value_chart" "FBHtz54AwAA" {
+    name                = "Builds Blocked"
+    color_by            = "Dimension"
+    is_timestamp_hidden = false
+    show_spark_line     = false
+    unit_prefix         = "Metric"
+    secondary_visualization = "None"
+
+    program_text = <<-EOF
+A = data('jenkins.queue.blocked', filter=filter('environment', '*') and filter('service.name', '*')).publish(label='A')
+    EOF
+}
+
+resource "signalfx_single_value_chart" "FBHncuWA0AE" {
+    name                = "Agents Offline"
+    color_by            = "Dimension"
+    is_timestamp_hidden = false
+    show_spark_line     = false
+    unit_prefix         = "Metric"
+    secondary_visualization = "None"
+
+    program_text = <<-EOF
+A = data('jenkins.agents.offline', filter=filter('environment', '*') and filter('service.name', '*')).publish(label='A')
+    EOF
+}
+
+resource "signalfx_time_chart" "FBHtToXA0AE" {
+    name                = "Successful vs Failed Jobs"
+    plot_type           = "ColumnChart"
+    unit_prefix         = "Metric"
+    color_by            = "Dimension"
+  
+
+    viz_options {
+      label = "A"
+      color = "orange"
+    }
+    viz_options {
+      label = "C"
+      color = "navy"
+    }
+
+    histogram_options {
+      color_theme = "red"
+    }
+
+    legend_options_fields {
+      enabled         = false
+      property        = "status.code"
+    }
+    legend_options_fields {
+      enabled         = true
+      property        = "ci.pipeline.id"
+    }
+    legend_options_fields {
+      enabled         = false
+      property        = "sf_originatingMetric"
+    }
+    legend_options_fields {
+      enabled         = true
+      property        = "sf_metric"
+    }
+    legend_options_fields {
+      enabled         = false
+      property        = "jenkins.pipeline.step.name"
+    }
+    legend_options_fields {
+      enabled         = false
+      property        = "sf_error"
+    }
+    legend_options_fields {
+      enabled         = true
+      property        = "sf_operation"
+    }
+
+    show_event_lines    = false
+
+    program_text = <<-EOF
+A = data('spans.count', filter=filter('sf_error', 'true') and filter('environment', '*') and filter('service.name', '*')).sum(by=['sf_error', 'sf_operation']).publish(label='A')
+C = data('spans.count', filter=filter('sf_error', 'false') and filter('environment', '*') and filter('service.name', '*')).sum(by=['sf_error', 'sf_operation']).publish(label='C')
+    EOF
+}
+
+
+resource "signalfx_single_value_chart" "FBHuYJdA4AA" {
+    name                = "Builds Running"
+    color_by            = "Dimension"
+    is_timestamp_hidden = false
+    show_spark_line     = false
+    unit_prefix         = "Metric"
+    secondary_visualization = "None"
+
+    program_text = <<-EOF
+A = data('jenkins.queue.buildable', filter=filter('environment', '*') and filter('service.name', '*')).publish(label='A')
+    EOF
+}
+
+resource "signalfx_single_value_chart" "FBHuIvZA0AA" {
+    name                = "Builds Left"
+    color_by            = "Dimension"
+    is_timestamp_hidden = false
+    show_spark_line     = false
+    unit_prefix         = "Metric"
+    secondary_visualization = "None"
+
+    program_text = <<-EOF
+A = data('jenkins.queue.left', filter=filter('environment', '*') and filter('service.name', '*')).publish(label='A')
+    EOF
+}
+
+resource "signalfx_time_chart" "FBHvQ1JA0AE" {
+    name                = "Number of Agents"
+    plot_type           = "LineChart"
+    unit_prefix         = "Metric"
+    color_by            = "Dimension"
+  
+
+    viz_options {
+      label = "A"
+    }
+
+    histogram_options {
+      color_theme = "red"
+    }
+
+
+    show_event_lines    = false
+
+    program_text = <<-EOF
+A = data('jenkins.agents.total', filter=filter('environment', '*') and filter('service.name', '*')).publish(label='A')
+    EOF
+}
+
+
+resource "signalfx_time_chart" "FBH3Uh5A0AA" {
+    name                = "Avg Queue Time(ms)"
+    plot_type           = "AreaChart"
+    unit_prefix         = "Metric"
+    color_by            = "Dimension"
+  
+
+    viz_options {
+      label = "A"
+    }
+
+    histogram_options {
+      color_theme = "red"
+    }
+
+    legend_options_fields {
+      enabled         = true
+      property        = "attributes.jenkins.pipeline.step.type"
+    }
+    legend_options_fields {
+      enabled         = false
+      property        = "sf_originatingMetric"
+    }
+    legend_options_fields {
+      enabled         = false
+      property        = "sf_metric"
+    }
+    legend_options_fields {
+      enabled         = true
+      property        = "jenkins.url"
+    }
+    legend_options_fields {
+      enabled         = true
+      property        = "os.type"
+    }
+    legend_options_fields {
+      enabled         = true
+      property        = "gcp_id"
+    }
+    legend_options_fields {
+      enabled         = true
+      property        = "host.type"
+    }
+    legend_options_fields {
+      enabled         = true
+      property        = "cloud.availability_zone"
+    }
+    legend_options_fields {
+      enabled         = true
+      property        = "telemetry.sdk.name"
+    }
+    legend_options_fields {
+      enabled         = true
+      property        = "telemetry.sdk.language"
+    }
+    legend_options_fields {
+      enabled         = true
+      property        = "host.name"
+    }
+    legend_options_fields {
+      enabled         = true
+      property        = "telemetry.sdk.version"
+    }
+    legend_options_fields {
+      enabled         = true
+      property        = "cloud.platform"
+    }
+    legend_options_fields {
+      enabled         = true
+      property        = "host.id"
+    }
+    legend_options_fields {
+      enabled         = true
+      property        = "service.name"
+    }
+    legend_options_fields {
+      enabled         = true
+      property        = "service.namespace"
+    }
+    legend_options_fields {
+      enabled         = true
+      property        = "cloud.provider"
+    }
+    legend_options_fields {
+      enabled         = true
+      property        = "environment"
+    }
+    legend_options_fields {
+      enabled         = true
+      property        = "service.version"
+    }
+    legend_options_fields {
+      enabled         = true
+      property        = "cloud.account.id"
+    }
+
+    show_event_lines    = false
+
+    program_text = <<-EOF
+A = data('jenkins.queue.time_spent_millis', filter=filter('environment', '*') and filter('service.name', '*')).publish(label='A')
+    EOF
+}
+
+
+resource "signalfx_list_chart" "FBH0_MVAwAA" {
+    name                = "Top Executed Steps (1h)"
+    color_by            = "Dimension"
+    unit_prefix         = "Metric"
+    secondary_visualization = "Sparkline"
+
+    legend_options_fields {
+      enabled         = true
+      property        = "attributes.jenkins.pipeline.step.type"
+    }
+
+    legend_options_fields {
+      enabled         = false
+      property        = "sf_originatingMetric"
+    }
+
+    legend_options_fields {
+      enabled         = false
+      property        = "sf_metric"
+    }
+
+    legend_options_fields {
+      enabled         = true
+      property        = "service.name"
+    }
+
+    legend_options_fields {
+      enabled         = true
+      property        = "jenkins.pipeline.step.name"
+    }
+
+    legend_options_fields {
+      enabled         = true
+      property        = "status.code"
+    }
+
+    legend_options_fields {
+      enabled         = true
+      property        = "span.kind"
+    }
+
+    legend_options_fields {
+      enabled         = true
+      property        = "jenkins.pipeline.step.type"
+    }
+
+    legend_options_fields {
+      enabled         = true
+      property        = "operation"
+    }
+
+    legend_options_fields {
+      enabled         = true
+      property        = "ci.pipeline.id"
+    }
+
+
+    program_text = <<-EOF
+B = data('jenkins.calls_total').sum(over='1h').sum(by=['jenkins.pipeline.step.name']).publish(label='B')
+A = data('jenkins.calls').sum(over='1h').sum(by=['jenkins.pipeline.step.name']).publish(label='A')
+    EOF
+}
+
+
+resource "signalfx_list_chart" "FBH3M7vA0AA" {
+    name                = "Top Failed Steps (1h)"
+    color_by            = "Dimension"
+    unit_prefix         = "Metric"
+    secondary_visualization = "Sparkline"
+
+    legend_options_fields {
+      enabled         = true
+      property        = "attributes.jenkins.pipeline.step.type"
+    }
+
+    legend_options_fields {
+      enabled         = false
+      property        = "sf_originatingMetric"
+    }
+
+    legend_options_fields {
+      enabled         = false
+      property        = "sf_metric"
+    }
+
+    legend_options_fields {
+      enabled         = true
+      property        = "jenkins.pipeline.step.name"
+    }
+
+
+    program_text = <<-EOF
+A = data('jenkins.calls', filter=filter('status.code', 'STATUS_CODE_ERROR')).sum(over='1h').sum(by=['jenkins.pipeline.step.name']).top(count=10).publish(label='A')
+    EOF
+}

--- a/dashboards/terraform-dashboards/main.tf
+++ b/dashboards/terraform-dashboards/main.tf
@@ -1,0 +1,20 @@
+terraform {
+  required_providers {
+    signalfx = {
+      source = "splunk-terraform/signalfx"
+      version = ">= 7.0.0"
+    }
+  }
+}
+
+
+provider "signalfx" {
+  #auth_token = "your-apu-key-goes-here"
+  #api_url = "observability-api-url-for-your-real" Example: https://api.us1.signalfx.com
+}
+
+## Create a dashboard group to reference with each dashboard
+resource "signalfx_dashboard_group" "jenkins-apm" {
+  name        = "Jenkins APM Dashboard Group"
+  description = "Dashboard group for Jenkins APM data"
+}

--- a/dashboards/terraform-dashboards/main.tf
+++ b/dashboards/terraform-dashboards/main.tf
@@ -9,8 +9,8 @@ terraform {
 
 
 provider "signalfx" {
-  #auth_token = "your-apu-key-goes-here"
-  #api_url = "observability-api-url-for-your-real" Example: https://api.us1.signalfx.com
+  #auth_token = "your-api-key-goes-here"
+  #api_url = "observability-api-url-for-your-realm" Example: https://api.us1.signalfx.com
 }
 
 ## Create a dashboard group to reference with each dashboard


### PR DESCRIPTION
This updates the configs and documentation to leverage the latest OpenTelemetry functions `transform`, `spanmetrics`, etc to create metrics for dashboards in Splunk Observability.
- Removes previous dependency on Log Observer for some metrics in dashboards

Includes updated dashboards included as JSON and Terraform 

updates gitignore for terraform files